### PR TITLE
Update DbSqlAdapterSqlite.php

### DIFF
--- a/runtime/DB/Adapter/SqlAdapter/DbSqlAdapterSqlite.php
+++ b/runtime/DB/Adapter/SqlAdapter/DbSqlAdapterSqlite.php
@@ -166,7 +166,7 @@ class LtDbSqlAdapterSqlite implements LtDbSqlAdapter
 			*/
 			$fields[$value['name']]['notnull'] = (bool) ($value['notnull'] != 0);
 			$fields[$value['name']]['default'] = $value['dflt_value'];
-			$fields[$value['name']]['primary'] = (bool) ($value['pk'] == 1 && strtoupper($fulltype) == 'INTEGER');
+			$fields[$value['name']]['primary'] = (bool) ($value['pk'] == 1 && strtoupper(substr($fulltype, 0, 7)) == 'INTEGER');
 		}
 		return $fields;
 	}


### PR DESCRIPTION
SQLite3中，修正主键设置了长度，如 ["type"]=>string(12) "INTEGER(3,0)" 时无法取到主键Bug。
